### PR TITLE
prevent import module while setup, add dependency django >= 1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 from setuptools import setup
-from djapiauth import __version__
+
+__version__ = '0.7'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
@@ -19,6 +20,7 @@ setup(
     url='https://github.com/feifangit/dj-api-auth',
     author='Fan Fei',
     author_email='feifan.pub@gmail.com',
+    install_requires=['Django >= 1.7'],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
In [setup.py#3](https://github.com/feifangit/dj-api-auth/blob/master/setup.py#L3), django will be import while module [init](https://github.com/feifangit/dj-api-auth/blob/master/djapiauth/__init__.py#L1), but django might haven't been installed.

Maybe we could hard code the version number on setup.py like this PR.
If you guys accept this approach, I could also PR on another [repo](https://github.com/feifangit/dj-sso-server) which has same issue.
